### PR TITLE
attempts to fix major test failure cases

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Date-Utility
 
+1.02	22/10/2015
+	Corrected a number of cases where tests failed
+	Bumping min perl version up to 5.10
+
 1.00    09/04/2015
         First version, released on an unsuspecting world.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
@@ -10,7 +10,7 @@ WriteMakefile(
     ABSTRACT_FROM    => 'lib/Date/Utility.pm',
     LICENSE          => 'artistic_2',
     PL_FILES         => {},
-    MIN_PERL_VERSION => 5.006,
+    MIN_PERL_VERSION => 5.010,
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
     },
@@ -29,6 +29,7 @@ WriteMakefile(
         'Scalar::Util'                       => 0,
         'Tie::Hash::LRU'                     => 0,
         'Time::Local'                        => 0,
+        'Time::Piece'                        => 0,
         'Try::Tiny'                          => 0,
         'Time::Duration::Concise::Localize'  => 2.5,
     },

--- a/lib/Date/Utility.pm
+++ b/lib/Date/Utility.pm
@@ -10,11 +10,11 @@ Date::Utility - A class that represents a datetime in various format
 
 =head1 VERSION
 
-Version 1.00
+Version 1.02
 
 =cut
 
-our $VERSION = '1.01';
+our $VERSION = '1.02';
 
 
 =head1 SYNOPSIS


### PR DESCRIPTION
This does a couple of things:
1.  Makes requirement to Time::Piece explicit (that way if there are further failures we get version info)
2.  Requires 5.10 as a minimum version (all 5.8 tests are failing, due to in Perl in the ensuing time).
